### PR TITLE
ros2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1847,9 +1847,8 @@
       "dev": true
     },
     "amphion": {
-      "version": "npm:@robostack/amphion@0.1.25",
-      "resolved": "https://registry.npmjs.org/@robostack/amphion/-/amphion-0.1.25.tgz",
-      "integrity": "sha512-kFoa+Ufa9MXKL8vQmryLXhJWXg3k4ge/M6xPxLs+sAO1yWCsItPn7WCnyu/OrClIINfz/6jqfmkv1sIvLhfStw==",
+      "version": "git+https://github.com/RoboStack/amphion.git#879045327e879d0bb6fe2c8eac54664de46ef675",
+      "from": "git+https://github.com/RoboStack/amphion.git",
       "requires": {
         "@juggle/resize-observer": "^2.2.1",
         "lodash.debounce": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/robostack/zethus/issues"
   },
   "dependencies": {
-    "amphion": "npm:@robostack/amphion@^0.1.25",
+    "amphion": "git+https://github.com/RoboStack/amphion.git",
     "brace": "^0.11.1",
     "classnames": "^2.2.6",
     "d3": "^5.16.0",
@@ -52,6 +52,7 @@
     "lint": "eslint src/**/*.{js,jsx} --fix",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
+    "prebuild": "cd node_modules/amphion && npm install && npm run build",
     "prettier": "prettier src/**/* --write"
   },
   "browserslist": [


### PR DESCRIPTION
This is the first attempt at getting the existing zethus app working with ROS2. Tested with tf2 messages only. 

The existing amphion dependency was 0.1.25:
```
"npm:@robostack/amphion@0.1.25"
```

However this doesn't contain the latest changes to master, which are supposed to enable ROS2 messages to be visualized. I had trouble simply switching the npm dependency for a github dependency (errors importing Amphion from javascript) so as a workaround I added a `prebuild` script which will jump in and build the amphion code before building zethus. This works for now. Created an issue as a reminder to look at this again/fix this later.